### PR TITLE
max frame length for spark 3.2

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -68,6 +68,7 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
         .withInt(MultipleRetryPolicy.MaxRetryCount, conf.queryRetryCount)
         .withDuration(DseDriverOption.CONTINUOUS_PAGING_TIMEOUT_FIRST_PAGE, Duration.ofMillis(conf.readTimeoutMillis))
         .withDuration(DseDriverOption.CONTINUOUS_PAGING_TIMEOUT_OTHER_PAGES, Duration.ofMillis(conf.readTimeoutMillis))
+        .withInt(PROTOCOL_MAX_FRAME_LENGTH, conf.maxFrameLengthInMB * 1024 * 1024)
     }
 
     // compression option cannot be set to NONE (default)

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -62,7 +62,8 @@ case class CassandraConnectorConf(
   connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory,
   quietPeriodBeforeCloseMillis: Int = CassandraConnectorConf.QuietPeriodBeforeCloseParam.default,
   timeoutBeforeCloseMillis: Int = CassandraConnectorConf.TimeoutBeforeCloseParam.default,
-  resolveContactPoints: Boolean = CassandraConnectorConf.ResolveContactPoints.default
+  resolveContactPoints: Boolean = CassandraConnectorConf.ResolveContactPoints.default,
+  maxFrameLengthInMB: Int = CassandraConnectorConf.MaxFrameLengthInMB.default,
 ) {
 
   override def hashCode: Int = HashCodeBuilder.reflectionHashCode(this, false)
@@ -332,6 +333,12 @@ object CassandraConnectorConf extends Logging {
     default = DefaultCassandraSSLConf.keyStoreType,
     description = """Key store type""")
 
+  val MaxFrameLengthInMB = ConfigParameter[Int](
+    name = "spark.cassandra.protocol.max-frame-length-mb",
+    section = ReferenceSection,
+    default = 256,
+    description = """The maximum length, in MB, of the frames supported by the driver. """)
+
   private def maybeResolveHostAndPort(hostAndPort: String, defaultPort: Int,
                                       resolveContactPoints: Boolean): Option[InetSocketAddress] = {
     val (hostName, port) = if (hostAndPort.contains(":")) {
@@ -429,6 +436,8 @@ object CassandraConnectorConf extends Logging {
 
     val connectionFactory = CassandraConnectionFactory.fromSparkConf(conf)
 
+    val maxFrameLengthInMB = conf.getInt(MaxFrameLengthInMB.name, MaxFrameLengthInMB.default)
+
     CassandraConnectorConf(
       contactInfo = getContactInfoFromSparkConf(conf),
       localDC = localDC,
@@ -444,7 +453,8 @@ object CassandraConnectorConf extends Logging {
       connectionFactory = connectionFactory,
       quietPeriodBeforeCloseMillis = quietPeriodBeforeClose,
       timeoutBeforeCloseMillis = timeoutBeforeClose,
-      resolveContactPoints = resolveContactPoints
+      resolveContactPoints = resolveContactPoints,
+      maxFrameLengthInMB = maxFrameLengthInMB
     )
   }
 


### PR DESCRIPTION
(cherry picked from commit 28e63cb1b52377d1cbbde8dbe0b8dd0eef851ff2)

# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Describe the problem, or state of the project that this patch fixes. Explain
why this is a problem if this isn't obvious.

Example: 
  "When I read from tables with 3 INTS I get a ThreeIntException(). This is a problem because I often want to read from a table with three integers."

## General Design of the patch

How the fix is accomplished, were new parameters or classes added? Why did you
pursue this particular fix?

Example: "I removed the incorrect assertion which would throw the ThreeIntException. This exception was incorrectly added and the assertion is not actually needed."

Fixes: [Put JIRA Reference HERE](https://datastax-oss.atlassian.net/projects/SPARKC)

# How Has This Been Tested?

Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

# Checklist:

- [ ] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [ ] I have performed a self-review of my own code
- [ ] Locally all tests pass (make sure tests fail without your patch)
